### PR TITLE
🐛: bug 다마고치의 캐릭터 레벨이 5가 되었을 때, 게임 클리어 메시지를 출력하도록 수정

### DIFF
--- a/src/TamaManager.java
+++ b/src/TamaManager.java
@@ -115,7 +115,8 @@ public class TamaManager {
                 tama.setImgURL("src/img/tamagochiImg1.png");
                 break;
         }
-        if(tama.getLevel()==6){
+        // 다마고치 5레벨 달성시 게임 clear
+        if(tama.getLevel()==5){
             myframe.gameClear();
         }
     }


### PR DESCRIPTION
다마고치의 캐릭터 레벨이 5가 되었을 때, 게임 클리어 메시지를 출력하도록 수정